### PR TITLE
Use input to checkout the required version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,10 @@
 FROM ubuntu:latest
 
-ARG VERSION=latest
-
 RUN apt-get update && \
   apt-get -y install software-properties-common && \
   add-apt-repository -y ppa:git-core/ppa && \
   apt-get -y install curl unzip git
 
-RUN echo "using version ${VERSION}"
-
-RUN mkdir /app
-
-RUN curl https://bearer-cli-binaries.s3.eu-west-1.amazonaws.com/${VERSION}/bearer-broker_linux_amd64.zip --output /app/bearer.zip
-
-WORKDIR /app
-
-RUN unzip /app/bearer.zip
-
 ADD ./entrypoint.sh /app/entrypoint.sh
-
-RUN chmod u+x -R /app
 
 ENTRYPOINT ["/app/entrypoint.sh" ]

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ branding:
   icon: "lock"
   color: "blue"
 inputs:
+  version:
+    description: Version of the binary to download.
+    default: latest
+    required: false
   github_token:
     description: The GitHub token used to create an authenticated client
     default: ${{ github.token }}
@@ -12,3 +16,5 @@ inputs:
 runs:
   using: "docker"
   image: "Dockerfile"
+  env:
+    VERSION: ${{ inputs.version }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 set -e
 
-cd /app/bearer-broker_linux_amd64/
+echo "Using version ${VERSION}"
+
+curl https://bearer-cli-binaries.s3.eu-west-1.amazonaws.com/${VERSION}/bearer-broker_linux_amd64.zip --output bearer.zip
+
+unzip bearer.zip
+
+chmod u+x -R bearer-broker_linux_amd64/
+
+cd bearer-broker_linux_amd64/
 ./broker


### PR DESCRIPTION
Allow version to be passed as an argument to download another version than latest.

See https://github.com/cfabianski/gitlabhq/pull/1/files

https://github.com/cfabianski/gitlabhq/runs/6367922112?check_suite_focus=true
<img width="2553" alt="image" src="https://user-images.githubusercontent.com/110196/168237782-5831ce74-9e16-4f77-8b14-3cb8c98600d9.png">
